### PR TITLE
Allow locking docker-hosted instances to a single domain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,15 @@ RUN npm run build
 
 # copy files to run container
 FROM nginx:stable-alpine
+
+# copy distribution from build step
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# expose and start nginx
+# install entrypoint script to /usr/local/bin/
+RUN mkdir -p /usr/local/bin/
+COPY ./scripts/docker-startup.sh /usr/local/bin/docker-startup.sh
+RUN chmod 700 /usr/local/bin/docker-startup.sh
+
+# expose and set entrypoint
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["sh", "/usr/local/bin/docker-startup.sh"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ services:
     restart: unless-stopped
     ports:
       - 9696:80
+    environment:
+      LOCK_DOMAIN: modder.example.com # optionally locks the domain that can be used with this instance
 ```
 2. Bring up the new container `docker-compose up -d lemmy-modder`
 3. Setup your reverse proxy to proxy requests for `modder.example.com` to the new container on port `80`.
@@ -100,9 +102,23 @@ npm start
 ```
 5. Open http://localhost:9696 in your browser
 
+
+### Testing Docker Image
+
+1. Build the docker image
+```
+docker build -t lemmy-modder:local .
+```
+
+2. Run the docker image _(with lock example)_
+```
+docker run --rm --env LOCK_DOMAIN="lemmy.tgxn.net" -p 9696:80 lemmy-modder:local
+```
+
+
 # Credits
 
-Lemmy  Devs https://github.com/LemmyNet
+Lemmy Devs https://github.com/LemmyNet
 
 Logo made by Andy Cuccaro (@andycuccaro) under the CC-BY-SA 4.0 license.
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     <meta name="description" content="Moderation Tooling for Lemmy " />
     <meta name="keywords" content="Lemmy, Social Data, Reddit" />
     <meta name="author" content="https://github.com/tgxn/lemmy-modder" />
+
+    <script src="/runtime-config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemmy-modder-frontend",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Lemmy Moderation App",
   "author": "tgxn",
   "license": "MIT",

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # load runtime configuration
-LOCK_DOMAIN=${LOCK_DOMAIN:-"false"}
+LOCK_DOMAIN=${LOCK_DOMAIN:-""}
 
 # store runtime configuration
 RUNTIME_CONFIG_FILE=/usr/share/nginx/html/runtime-config.js

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# load runtime configuration
+LOCK_DOMAIN=${LOCK_DOMAIN:-"false"}
+
+# store runtime configuration
+RUNTIME_CONFIG_FILE=/usr/share/nginx/html/runtime-config.js
+if [ -f $RUNTIME_CONFIG_FILE ]; then
+    rm $RUNTIME_CONFIG_FILE
+fi
+
+echo "$(cat <<EOM
+// runtime-config.js
+window['RuntimeConfig'] = {
+    DomainLock: "${LOCK_DOMAIN}"
+};
+EOM
+)" > $RUNTIME_CONFIG_FILE
+
+# Start Nginx (default entrypoint)
+exec nginx -g "daemon off;"

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -27,7 +27,7 @@ import { addUser, setAccountIsLoading, setUsers, setCurrentUser } from "../reduc
 import { BasicInfoTooltip } from "../components/Tooltip.jsx";
 
 export default function LoginForm() {
-  const domainLock = window?.RuntimeConfig?.DomainLock || false;
+  const domainLock = window?.RuntimeConfig?.DomainLock != "" ? window?.RuntimeConfig?.DomainLock : false;
   console.log("RuntimeConfig DomainLock", domainLock);
 
   const dispatch = useDispatch();

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -27,6 +27,9 @@ import { addUser, setAccountIsLoading, setUsers, setCurrentUser } from "../reduc
 import { BasicInfoTooltip } from "../components/Tooltip.jsx";
 
 export default function LoginForm() {
+  const domainLock = window?.RuntimeConfig?.DomainLock || false;
+  console.log("RuntimeConfig DomainLock", domainLock);
+
   const dispatch = useDispatch();
 
   const accountIsLoading = useSelector((state) => state.accountReducer.accountIsLoading);
@@ -34,7 +37,7 @@ export default function LoginForm() {
   const isInElectron = useSelector((state) => state.configReducer.isInElectron);
 
   // form state
-  const [instanceBase, setInstanceBase] = React.useState("");
+  const [instanceBase, setInstanceBase] = React.useState(domainLock ? domainLock : "");
   const [username, setUsername] = React.useState("");
   const [password, setPassword] = React.useState("");
 
@@ -147,11 +150,11 @@ export default function LoginForm() {
             <Input
               placeholder="Instance URL"
               value={instanceBase}
-              onChange={(e) => setInstanceBase(e.target.value)}
+              onChange={(e) => (domainLock ? null : setInstanceBase(e.target.value))}
               variant="outlined"
               color="neutral"
               sx={{ mb: 1, width: "100%" }}
-              disabled={accountIsLoading}
+              disabled={domainLock || accountIsLoading}
             />
             <Input
               placeholder="Username"
@@ -179,14 +182,6 @@ export default function LoginForm() {
               }}
               disabled={accountIsLoading}
             />
-            <Button
-              fullWidth
-              onClick={loginClick}
-              disabled={instanceBase.length === 0 || username.length === 0 || password.length === 0}
-              loading={accountIsLoading}
-            >
-              Login
-            </Button>
             <Box
               sx={{
                 py: 1,
@@ -201,6 +196,14 @@ export default function LoginForm() {
                 />
               </BasicInfoTooltip>
             </Box>
+            <Button
+              fullWidth
+              onClick={loginClick}
+              disabled={instanceBase.length === 0 || username.length === 0 || password.length === 0}
+              loading={accountIsLoading}
+            >
+              Login
+            </Button>
           </Box>
 
           {loginError && (


### PR DESCRIPTION
This adds `LOCK_DOMAIN` envvar that can be used to restrict the instances you have available:
![image](https://github.com/tgxn/lemmy-modder/assets/293107/2e2833a3-e5c5-4cba-ab45-20d29554e4be)

Since we're only client-side, this currently offers no protection, but it allows you to default this value for your own instances.